### PR TITLE
chore: use shared-workflows-public for reusable workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   release:
-    uses: Nvision-x/shared-workflows/.github/workflows/calver-release.yml@main
+    uses: Nvision-x/shared-workflows-public/.github/workflows/calver-release.yml@main


### PR DESCRIPTION
Point reusable workflow references from the private `shared-workflows` repo to the public `shared-workflows-public` repo.